### PR TITLE
Deal with special characters in parameters

### DIFF
--- a/jquery.fileDownload.js
+++ b/jquery.fileDownload.js
@@ -172,10 +172,13 @@ $.extend({
             var formInputs = "";
             if (settings.data !== null) {
 
-                $.each(settings.data.split("&"), function () {
+                $.each(settings.data.replace(/\+/g, ' ').split("&"), function () {
 
                     var kvp = this.split("=");
-                    formInputs += "<input type='text' name='" + kvp[0] + "' value='" + kvp[1] + "'/>";
+                    var key = decodeURIComponent(kvp[0]);
+                    if ( !key ) return;
+                    var value = decodeURIComponent(kvp[1] || '');
+                    formInputs += $("<input type='text'>").attr("name", key).attr("value", value).wrap("<p>").parent().html();
                 });
             }
 


### PR DESCRIPTION
As the code is now, when building a from for a non-GET request, it simply splits the param string with & and = and takes the strings as is. This breaks when a parameter contains any "special" character  for two reasons:
1. All the strings are URI-encoded, so anything non-ascii or non alphanumeric gets converted to %2C and the likes.
2. When creating the form element, no HTML escaping is done.

Problem 2 manifests after solving problem 1, when quotes in values appear literally and mangle the HTML output.

This pull request fixes both problems.
