### PR TITLE
Wrap extension in anonymous function

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -9,7 +9,7 @@
 *   http://www.opensource.org/licenses/mit-license.php
 */
 
-var $ = jQuery.noConflict();
+(function($){
 
 $.extend({
     //
@@ -408,3 +408,4 @@ $.extend({
     }
 });
 
+})(jQuery);


### PR DESCRIPTION
Declaring a global variable and calling jQuery.noConflict changes a lot the global scope, and this may lead to confilcts with user scripts.

As suggested by official documentation, it's better to just wrap all the extension in an autocalling anonymous function.

http://docs.jquery.com/Plugins/Authoring#Getting_Started
