### PR TITLE
Add timeout option

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -94,6 +94,12 @@ $.extend({
             checkInterval: 100,
 
             //
+            // A period in milliseconds after which the download should be considered failed and polling will cease
+            // The default of 0 means the timeout will be ignored
+            //
+            timeout: 0
+
+            //
             //the cookie name to indicate if a file download has occured
             //
             cookieName: "fileDownload",
@@ -220,7 +226,8 @@ $.extend({
         var $iframe,
             downloadWindow,
             formDoc,
-            $form;
+            $form,
+            startTime;
 
         if (httpMethodUpper === "GET") {
 
@@ -310,10 +317,10 @@ $.extend({
             $form.submit();
         }
 
+        startTime = Date.getTime();
 
         //check if the file download has completed every checkInterval ms
         setTimeout(checkFileDownloadComplete, settings.checkInterval);
-
 
         function checkFileDownloadComplete() {
 
@@ -340,7 +347,8 @@ $.extend({
 
                     var formDoc = downloadWindow ? downloadWindow.document : getiframeDocument($iframe);
 
-                    if (formDoc && formDoc.body != null && formDoc.body.innerHTML.length) {
+                    if ( (formDoc && formDoc.body != null && formDoc.body.innerHTML.length)
+                        || (timeout != 0 && startTime + settings.timeout > Date.getTime()) ) {
 
                         var isFailure = true;
 
@@ -371,7 +379,6 @@ $.extend({
                     return;
                 }
             }
-
 
             //keep checking...
             setTimeout(checkFileDownloadComplete, settings.checkInterval);


### PR DESCRIPTION
Adds a timeout option for use if the failed download can't be detected.
Default is to never use a timeout, unless it is passed in as option.
