### PR TITLE
Mobile Chrome fails to download unsafe files

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -129,12 +129,17 @@ $.extend({
         var userAgent = (navigator.userAgent || navigator.vendor || window.opera).toLowerCase();
 
         var isIos;                  //has full support of features in iOS 4.0+, uses a new window to accomplish this.
+        var isChrome;               //mobile chrome does not need to be treated like the stock android browser
         var isAndroid;              //has full support of GET features in 4.0+ by using a new window. Non-GET is completely unsupported by the browser. See above for specifying a message.
         var isOtherMobileBrowser;   //there is no way to reliably guess here so all other mobile devices will GET and POST to the current window.
 
         if (/ip(ad|hone|od)/.test(userAgent)) {
 
             isIos = true;
+
+        } else if (userAgent.indexOf('chrome') !== -1) {
+
+            isChrome = true;
 
         } else if (userAgent.indexOf('android') !== -1) {
 


### PR DESCRIPTION
Chrome browser supplied with modern android devices (4.0 and newer) provides a warning for the user if the browser starts downloading an 'unsafe' file (like an .apk file) that requires user confirmation to continue.

The way the plugin handles the download on android devices (by opening and closing a new browser window) the warning is hidden before the user has a chance to confirm, in effect no file is downloaded.

I believe mobile Chrome browser can handle download via an iframe just as good as a desktop version and this is fixed by detecting it's user agent and using the iframe download method rather than the android-stock-browser-specific one.
