### PR TITLE
Include fail reason cookie

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * jQuery File Download Plugin v1.4.2 
 *
 * http://www.johnculviner.com
@@ -75,7 +75,8 @@ $.extend({
             //                      server's error message with a "helpful" IE built in message
             //  url             - the original url attempted
             //
-            failCallback: function (responseHtml, url) { },
+            //  failReason      - the reason provided within the response cookie
+            failCallback: function (responseHtml, url, failReason) { },
 
             //
             // the HTTP method to use. Defaults to "GET".
@@ -102,6 +103,11 @@ $.extend({
             //the cookie value for the above name to indicate that a file download has occured
             //
             cookieValue: "true",
+
+            //
+            //the cookie name to provide a reason if failure
+            //
+            cookieNameFailReason: "fileDownloadFailureReason",
 
             //
             //the cookie path for above name value pair
@@ -191,7 +197,7 @@ $.extend({
                 deferred.resolve(url);
             },
 
-            onFail: function (responseHtml, url) {
+            onFail: function (responseHtml, url, failReason) {
 
                 //remove the perparing message if it was specified
                 if ($preparingDialog) {
@@ -203,7 +209,7 @@ $.extend({
                     $("<div>").html(settings.failMessageHtml).dialog(settings.dialogOptions);
                 }
 
-                settings.failCallback(responseHtml, url);
+                settings.failCallback(responseHtml, url, failReason);
                 
                 deferred.reject(responseHtml, url);
             }
@@ -353,7 +359,21 @@ $.extend({
                         }
 
                         if (isFailure) {
-                            internalCallbacks.onFail(formDoc.body.innerHTML, fileUrl);
+                            var failreasonIndex = document.cookie.indexOf(settings.cookieNameFailReason);
+                            var failReason = undefined;
+                            if (failreasonIndex != -1) {
+                                var i, x, y, ARRcookies = document.cookie.split(";");
+                                for (i = 0; i < ARRcookies.length; i++) {
+                                    x = ARRcookies[i].substr(0, ARRcookies[i].indexOf("="));
+                                    y = ARRcookies[i].substr(ARRcookies[i].indexOf("=") + 1);
+                                    x = x.replace(/^\s+|\s+$/g, "");
+                                    if (x === settings.cookieNameFailReason) {
+                                        failReason = unescape(y);
+                                    }
+                                }
+                            }
+ 
+                            internalCallbacks.onFail(formDoc.body.innerHTML, fileUrl, failReason);
 
                             cleanUp(true);
 
@@ -364,7 +384,7 @@ $.extend({
                 catch (err) {
 
                     //500 error less than IE9
-                    internalCallbacks.onFail('', fileUrl);
+                    internalCallbacks.onFail('', fileUrl, '');
 
                     cleanUp(true);
 


### PR DESCRIPTION
Include code from:
https://github.com/johnculviner/jquery.fileDownload/issues/27

Since the fail response is sent separate from the responseHTML there was no need to provide a default.
