### PR TITLE
Return Fail reason cookie, frameid support and fileDownloadSetup object

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -25,9 +25,8 @@
 				'"': 'quot;',
 				"'": 'apos;' /*single quotes just to be safe*/
 	};
-
-$.extend({
-        defaultSettings: {
+	var nextAutoFrameIdNumber = 1;
+        var defaultSettings = {
             //
             //Requires jQuery UI: provide a message to display to the user when the file download is being prepared before the browser's dialog appears
             //
@@ -132,10 +131,11 @@ $.extend({
 
             //set the timeout of cleanUp function, the value should > 0 for browser latency
             timeout: 10
-        },
-        
+        };
+
+$.extend({        
         fileDownloadSetup: function(settings) {
-            $.extend(defaultSettings, settings);
+            defaultSettings = $.extend(defaultSettings, settings);
         },
         
         //


### PR DESCRIPTION
- Base 1.4.2 plus:
-  Create $.fileDownloadSetup to support default configurations https://github.com/austinjones/jquery.fileDownload/commit/78da2fa10c9c4d72a6d234141c18a3684ef4af28
-  Return fail reason cookie https://github.com/mattiamascia/jquery.fileDownload/commit/974a8f1f04a00440fbf38c832c43e74b2c7499d2
-  FrameId support for multiple downloads https://github.com/mattiamascia/jquery.fileDownload/commit/974a8f1f04a00440fbf38c832c43e74b2c7499d2
