### PR TITLE
Link to jquery_file_download-rails gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ http://johnculviner.com/category/jQuery-File-Download.aspx
 ###Or look at the well documented JavaScript source:
 https://github.com/johnculviner/jquery.fileDownload/blob/master/src/Scripts/jquery.fileDownload.js
 
+### Ruby on Rails integration
+
+The [`jquery_file_download-rails`](https://github.com/rcook/jquery_file_download-rails)
+gem integrates `jquery.fileDownload.js` into the Rails 3.1+ asset pipeline.
+


### PR DESCRIPTION
Add link to `jquery_file_download-rails` gem. This is a simple Ruby gem I created that integrates `jquery.fileDownload.js` into the Rails 3.1+ asset pipeline.
