### PR TITLE
Fix issue with IE8 and single quotes

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -24,7 +24,7 @@
 				'\r': "#13;",
 				'\n': "#10;",
 				'"': 'quot;',
-				"'": 'apos;' /*single quotes just to be safe*/
+				"'": '#39;' /*single quotes just to be safe, IE8 doesn't support &apos;, so use &#39; instead */
 	};
 
 $.extend({


### PR DESCRIPTION
IE8 doesn't support `&apos;`, so don't use it when building encoded forms - use `&#39;` instead, which all browsers support.
