### PR TITLE
Added support for working with cookies set on a subdomain

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -114,6 +114,12 @@ $.extend({
             cookiePath: "/",
 
             //
+            //if specified it will be used when attempting to clear the above name value pair
+            //useful for when downloads are being served on a subdomain (e.g. downloads.example.com)
+            //	
+            cookieDomain: null,
+
+            //
             //the title for the popup second window as a download is processing in the case of a mobile browser
             //
             popupWindowTitle: "Initiating file download...",
@@ -321,16 +327,18 @@ $.extend({
 
 
         function checkFileDownloadComplete() {
-
             //has the cookie been written due to a file download occuring?
             if (document.cookie.indexOf(settings.cookieName + "=" + settings.cookieValue) != -1) {
 
                 //execute specified callback
                 internalCallbacks.onSuccess(fileUrl);
 
-                //remove the cookie and iframe
-                document.cookie = settings.cookieName + "=; expires=" + new Date(1000).toUTCString() + "; path=" + settings.cookiePath;
+                //remove cookie
+                var cookieData = settings.cookieName + "=; path=" + settings.cookiePath + "; expires=" + new Date(0).toUTCString() + ";";
+                if (settings.cookieDomain) cookieData += " domain=" + settings.cookieDomain + ";";
+                document.cookie = cookieData;
 
+                //remove iframe
                 cleanUp(false);
 
                 return;


### PR DESCRIPTION
I used this plugin on my project, but I was required to serve files from my API which sits on an alternate subdomain than the site itself.

> **Example:**
> Site on http://www.example.com downloads a file on http://download.example.com

Setting the domain property of the cookie on the API allowed this plugin to work.

> **Example:**
> (Set Cookie: fileDownload=true; Path=/; Domain=example.com)

However, the cookie would not get cleared and so subsequent downloads would fire the success event immediately.

My alterations allow you to set the domain where cookies are expected to be cleared. It can be used as follows:

``` javascript
$.fileDownload(requestUrl, {
    // The domain to clear cookies from
    cookieDomain: "example.com"
})
```

My project resides on different domains as we have different environments for development, stage, production. In such a scenario you may want to use the following:

``` javascript
$.fileDownload(requestUrl, {
    // The domain to clear cookies from
    // Below will equate to the base domain (e.g. example.com, not www.example.com)
    cookieDomain: window.location.hostname.split(".").slice(-2).join(".")
})
```
