### PR TITLE
Patch for stability. Unfinished process fix

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -134,6 +134,11 @@ $.extend({
             encodeHTMLEntities: true
             
         }, options);
+        
+        // remove the previous cookie that might be left unfinished from the previous process
+        var cookieData = settings.cookieName + "=; path=" + settings.cookiePath + "; expires=" + new Date(0).toUTCString() + ";";
+        if (settings.cookieDomain) cookieData += " domain=" + settings.cookieDomain + ";";
+        document.cookie = cookieData;
 
         var deferred = new $.Deferred();
 


### PR DESCRIPTION
If the previous process was not completed, the cookie may be information that breaks the plugin work. Need to clean it before starting a new process