### PR TITLE
Made cookie filename comparison case insensitive.

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -329,7 +329,9 @@ $.extend({
 
         function checkFileDownloadComplete() {
             //has the cookie been written due to a file download occuring?
-            if (document.cookie.indexOf(settings.cookieName + "=" + settings.cookieValue) != -1) {
+            var lowerCaseCookie = settings.cookieName.toLowerCase() + "=" + settings.cookieValue.toLowerCase();
+
+            if (document.cookie.toLowerCase().indexOf(lowerCaseCookie) > -1) {
 
                 //execute specified callback
                 internalCallbacks.onSuccess(fileUrl);


### PR DESCRIPTION
I implemented fileDownload.js in a ColdFusion application, and the problem with ColdFusion is that it sets cookies (with cfcookie) by uppercasing all characters. So when I set a cookie named "fileDownload", ColdFusion will create a cookie called "FILEDOWNLOAD".

This means that jquery.fileDownload will not recognize the cookie and will never fire the success event. It took me quite a bit of time to figure out the cause, so I hope I can prevent others from spending hours trying to debug this problem.

I submitted a pull request that changes the cookie name comparison to case insensitive.