### PR TITLE
Update bower.json with current version 1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/johnculviner/jquery.fileDownload/blob/master/src/Scripts/jque
 * Internet Explorer 6+ - Works fine for standard use cases except in < IE9 JavaScript access to the *failed* response HTML doesn't (and can't) work reliably due to browser iframe constraints.
 * Firefox 11+ - reasonably sure it will work on earlier versions
 * Chrome 17+ - reasonably sure it will work on earlier versions
-* iOS 5.0+ - reasonably sure it will work on earlier versions 
+* iOS 5.0+ - reasonably sure it will work on earlier versions
 * Android 4.0+ - non-GET requests do not work due to a long-standing [bug](http://code.google.com/p/android/issues/detail?id=1780) in the Android browser. This is handled 'gracefully' with a message to the user.
 
 ###Demo (of this exact source):

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-	"name": "jquery.filedownload",
+	"name": "jquery-file-download",
 	"description":"jQuery File Download is a cross server platform compatible jQuery plugin that allows for an Ajax-like file download experience that is not normally possible using the web.",
-	"version":"1.4.1",
+	"version":"1.4.4",
 	"keywords": [
 		"download",
 		"ajax"


### PR DESCRIPTION
* current version 1.4.4 found in src/Scripts/jquery.fileDownload.js
* update bower.json name attr to the name found on the bower.io registry for this repo
* remove a trailing whitespace in README.md