### PR TITLE
send window if `this` is undefined

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -490,4 +490,4 @@ $.extend({
     }
 });
 
-})(jQuery, this);
+})(jQuery, this || window);


### PR DESCRIPTION
if requiring the npm module and find that the value of `this` is `undefined` init with `window` instead of `undefined`