### PR TITLE
fallback to window if `this` is undefined

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -490,4 +490,4 @@ $.extend({
     }
 });
 
-})(jQuery, this);
+})(jQuery, this || window);


### PR DESCRIPTION
John,

Regarding the conversation in https://github.com/johnculviner/jquery.fileDownload/pull/133 -- I decided to refactor the implementation to avoid the issue I referenced previously.

I am resubmitting the original PR that provided the fallback of `window` if `this` is `undefined`