### PR TITLE
Fix browser GET requests.

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -288,10 +288,7 @@ $.extend({
             } else {
 
                 //create a temporary iframe that is used to request the fileUrl as a GET request
-                $iframe = $("<iframe>")
-                    .hide()
-                    .prop("src", fileUrl)
-                    .appendTo("body");
+		$iframe = $("<iframe style='display: none' src='"+fileUrl+"'></iframe>").appendTo("body");
             }
 
         } else {


### PR DESCRIPTION
Same code for browser GET than for POST.
The current GET code breaks on angularjs
```
Error: c is null
Ra@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:3:27236
Sa@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:3:27328
css@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:3:30850
W@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:3:3790
cb@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:3:28734
hide@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:4:614
n.fn[b]@http://127.0.0.1:6100/js/jquery-1.12.0.min.js:4:7545
fileDownload@http://127.0.0.1:6100/js/jquery.fileDownload.js:274:27
$scope.export_csv@http://127.0.0.1:6100/js/controllers/report_controller.js:76:5
fn@http://127.0.0.1:6100/js/angular.min.js line 223 > Function:4:223
b@http://127.0.0.1:6100/js/angular.min.js:121:483
e@http://127.0.0.1:6100/js/angular.min.js:265:177
$eval@http://127.0.0.1:6100/js/angular.min.js:140:363
$apply@http://127.0.0.1:6100/js/angular.min.js:141:83
compile/</<@http://127.0.0.1:6100/js/angular.min.js:265:227
Pf@http://127.0.0.1:6100/js/angular.min.js:36:475
d@http://127.0.0.1:6100/js/angular.min.js:36:424
angular.min.js:114:35 
```

This change fixes the issue.