### PR TITLE
drhuffman12/enable_android_non_get_downloads

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -46,13 +46,13 @@ $.extend({
             //
             failMessageHtml: null,
 
-            //
+            //Non-get Downloads work in newer Chrome browsers for Android; androidPostUnsupportedMessageHtml should be Deprecated.
             //the stock android browser straight up doesn't support file downloads initiated by a non GET: http://code.google.com/p/android/issues/detail?id=1780
             //specify a message here to display if a user tries with an android browser
             //if jQuery UI is installed this will be a dialog, otherwise it will be an alert
             //Set to null to disable the message and attempt to download anyway
             //
-            androidPostUnsupportedMessageHtml: "Unfortunately your Android browser doesn't support this type of file download. Please try again with a different browser.",
+            androidPostUnsupportedMessageHtml: "Deprecated and usage has been removed; you shouldn't see this message!",
 
             //
             //Requires jQuery UI: options to pass into jQuery UI Dialog
@@ -167,18 +167,6 @@ $.extend({
         }
 
         var httpMethodUpper = settings.httpMethod.toUpperCase();
-
-        if (isAndroid && httpMethodUpper !== "GET" && settings.androidPostUnsupportedMessageHtml) {
-            //the stock android browser straight up doesn't support file downloads initiated by non GET requests: http://code.google.com/p/android/issues/detail?id=1780
-
-            if ($().dialog) {
-                $("<div>").html(settings.androidPostUnsupportedMessageHtml).dialog(settings.dialogOptions);
-            } else {
-                alert(settings.androidPostUnsupportedMessageHtml);
-            }
-
-            return deferred.reject();
-        }
 
         var $preparingDialog = null;
 


### PR DESCRIPTION
I think it is time for `androidPostUnsupportedMessageHtml` to be deprecated. Non-get Downloads work in newer Chrome browsers for Android (at least Android 8); I'm guessing other browsers and less recent Android OS versions. Larger-scale testing should be done to confirm and weighed against [Platform versions](https://developer.android.com/about/dashboards/).