### PR TITLE
Fix for jQuery deprecation of event shorthand: submit

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -342,7 +342,7 @@ $.extend({
                 $form = $(formDoc).find('form');
             }
 
-            $form.submit();
+            $form.trigger("submit");
         }
 
 


### PR DESCRIPTION
Fix for jQuery deprecation notice when using with 3.0+

> jquery-migrate-3.1.0.js:99 JQMIGRATE: jQuery.fn.submit() event shorthand is deprecated
migrateWarn @ jquery-migrate-3.1.0.js:99
jQuery.fn.<computed> @ jquery-migrate-3.1.0.js:528
fileDownload @ jquery.fileDownload.js:329