### PR TITLE
Update for Jquery 3

### DIFF
--- a/src/Scripts/jquery.fileDownload.js
+++ b/src/Scripts/jquery.fileDownload.js
@@ -342,7 +342,7 @@ $.extend({
                 $form = $(formDoc).find('form');
             }
 
-            $form.submit();
+            $form.trigger('submit');
         }
 
 


### PR DESCRIPTION
.submit is deprecated in jquery 3.3 - convert to .trigger('submit') to eliminate JQMigrate warnings.

`/**
 * Bind an event handler to the "submit" JavaScript event, or trigger that event on an element.
 *
 * @param handler A function to execute each time the event is triggered.
 * @see {@link https://api.jquery.com/submit/}
 * @since 1.0
 * @deprecated 3.3
 */`